### PR TITLE
Fixed Windows TzInfo Issue and JWT Version Issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'jwt'
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     faker (1.6.1)
       i18n (~> 0.5)
     ffi (1.9.10)
+    ffi (1.9.10-x86-mingw32)
     formatador (0.2.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -105,7 +106,7 @@ GEM
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
     json (1.8.3)
-    jwt (1.5.3)
+    jwt (1.5.4)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -126,8 +127,11 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     mysql2 (0.4.2)
+    mysql2 (0.4.2-x86-mingw32)
     nenv (0.3.0)
     nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x86-mingw32)
       mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -211,6 +215,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    sqlite3 (1.3.11-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -231,6 +236,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   activerecord-import
@@ -257,3 +263,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
# Why?

The JWT gem was using a version that no longer existed in the Ruby Gems repo
and without tzinfo-data, running the app in Windows doesn't work.
# What Changed?

Updated the jwt gem to a version inside the Ruby Gems repo and added the tzinfo-data
for the windows platforms.
